### PR TITLE
Added bitrate setting (#26)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/activities/SettingsActivity.kt
@@ -10,10 +10,10 @@ import com.simplemobiletools.commons.helpers.isQPlus
 import com.simplemobiletools.commons.models.RadioItem
 import com.simplemobiletools.voicerecorder.R
 import com.simplemobiletools.voicerecorder.extensions.config
-import com.simplemobiletools.voicerecorder.helpers.EXTENSION_M4A
-import com.simplemobiletools.voicerecorder.helpers.EXTENSION_MP3
+import com.simplemobiletools.voicerecorder.helpers.*
 import kotlinx.android.synthetic.main.activity_settings.*
 import java.util.*
+import kotlin.collections.ArrayList
 
 class SettingsActivity : SimpleActivity() {
 
@@ -32,6 +32,7 @@ class SettingsActivity : SimpleActivity() {
         setupHideNotification()
         setupSaveRecordingsFolder()
         setupExtension()
+        setupBitrate()
         updateTextColors(settings_scrollview)
     }
 
@@ -107,4 +108,18 @@ class SettingsActivity : SimpleActivity() {
             }
         }
     }
+
+    private fun setupBitrate() {
+        settings_bitrate.text = getBitrateText(config.bitrate)
+        settings_bitrate_holder.setOnClickListener {
+            val items = BITRATES.map { RadioItem(it, getBitrateText(it)) } as ArrayList
+
+            RadioGroupDialog(this@SettingsActivity, items, config.bitrate) {
+                config.bitrate = it as Int
+                settings_bitrate.text = getBitrateText(config.bitrate)
+            }
+        }
+    }
+
+    private fun getBitrateText(value: Int): String = getString(R.string.bitrate_value).format(value / 1000)
 }

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Config.kt
@@ -21,6 +21,10 @@ class Config(context: Context) : BaseConfig(context) {
         get() = prefs.getInt(EXTENSION, EXTENSION_M4A)
         set(extension) = prefs.edit().putInt(EXTENSION, extension).apply()
 
+    var bitrate: Int
+        get() = prefs.getInt(BITRATE, DEFAULT_BITRATE)
+        set(bitrate) = prefs.edit().putInt(BITRATE, bitrate).apply()
+
     fun getExtensionText() = context.getString(when (extension) {
         EXTENSION_M4A -> R.string.m4a
         else -> R.string.mp3

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Constants.kt
@@ -17,6 +17,9 @@ const val TOGGLE_PAUSE = PATH + "TOGGLE_PAUSE"
 const val EXTENSION_M4A = 0
 const val EXTENSION_MP3 = 1
 
+val BITRATES = arrayListOf(320000, 256000, 192000, 160000, 128000, 96000, 64000, 32000)
+const val DEFAULT_BITRATE = 128000
+
 const val RECORDING_RUNNING = 0
 const val RECORDING_STOPPED = 1
 const val RECORDING_PAUSED = 2
@@ -25,6 +28,7 @@ const val RECORDING_PAUSED = 2
 const val HIDE_NOTIFICATION = "hide_notification"
 const val SAVE_RECORDINGS = "save_recordings"
 const val EXTENSION = "extension"
+const val BITRATE = "BITRATE"
 
 @SuppressLint("InlinedApi")
 fun getAudioFileContentUri(id: Long): Uri {

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/services/RecorderService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/services/RecorderService.kt
@@ -76,7 +76,7 @@ class RecorderService : Service() {
             setAudioSource(MediaRecorder.AudioSource.CAMCORDER)
             setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
             setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
-            setAudioEncodingBitRate(128000)
+            setAudioEncodingBitRate(config.bitrate)
             setAudioSamplingRate(44100)
 
             try {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -186,5 +186,37 @@
                 android:clickable="false" />
 
         </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/settings_bitrate_holder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/medium_margin"
+            android:background="?attr/selectableItemBackground"
+            android:paddingLeft="@dimen/normal_margin"
+            android:paddingTop="@dimen/bigger_margin"
+            android:paddingRight="@dimen/normal_margin"
+            android:paddingBottom="@dimen/bigger_margin">
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_bitrate_label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/settings_bitrate"
+                android:paddingLeft="@dimen/medium_margin"
+                android:paddingRight="@dimen/medium_margin"
+                android:text="@string/bitrate" />
+
+            <com.simplemobiletools.commons.views.MyTextView
+                android:id="@+id/settings_bitrate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="@dimen/small_margin"
+                android:background="@null"
+                android:clickable="false" />
+
+        </RelativeLayout>
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Forsøg at skjule notifikation under optagelse</string>
     <string name="save_recordings_in">Gem optagelser i</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Kan jeg skjule notifikationsikonet under optagelse?</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Versuche die Aufnahmebenachrichtigung auszublenden</string>
     <string name="save_recordings_in">Speichere Aufnahme in</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Kann ich das Benachrichtigungssymbol während der Aufnahme ausblenden?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Δοκιμάστε να αποκρύψετε την ειδοποίηση εγγραφής</string>
     <string name="save_recordings_in">Αποθήκευση εγγραφών σε</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Μπορώ να αποκρύψω το εικονίδιο ειδοποίησης κατά την εγγραφή;</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Tratar de ocultar la notificación de grabación</string>
     <string name="save_recordings_in">Guardar grabaciones en</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">¿Puedo ocultar el ícono de notificación durante la grabación?</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -18,6 +18,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Yritä piilottaa tallennusilmoitus</string>
     <string name="save_recordings_in">Tallenna tallenteet</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Voinko piilottaa ilmoituskuvakkeen tallennuksen aikana?</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Coba sembunyikan pemberitahuan rekaman</string>
     <string name="save_recordings_in">Simpan rekaman di</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Bisakah saya menyembunyikan ikon notifikasi selama merekam?</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Prova a nascondere la notifica di registrazione</string>
     <string name="save_recordings_in">Salva le registrazioni in</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Posso nascondere la notifica durante la registrazione?</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">録音通知を隠す</string>
     <string name="save_recordings_in">録音を保存する</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">録音中に通知を非表示にすることは出来ますか？</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Pabandyti paslėpti įrašymo pranešimą</string>
     <string name="save_recordings_in">Išsaugoti įrašus</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Ar galiu paslėpti pranešimo ikonėlę įrašinėjant?</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Tijdens de opname proberen de notificatie te verbergen</string>
     <string name="save_recordings_in">Opnames opslaan in</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Kan ik de notificatie tijdens het opnemen verbergen?</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -18,6 +18,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Spróbuj ukrywać powiadomienie o nagrywaniu</string>
     <string name="save_recordings_in">Zapisuj nagrania w</string>
+    <string name="bitrate">Jakość (przepływność)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Czy mogę ukryć ikonę powiadomienia podczas nagrywania?</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Tentar ocultar a notificação da gravação</string>
     <string name="save_recordings_in">Guardar gravações em</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Can I hide the notification icon during recording?</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -18,6 +18,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Пытаться скрыть уведомление о записи</string>
     <string name="save_recordings_in">Место хранения записей</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Можно ли скрыть значок уведомления во время записи?</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -18,6 +18,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Skúsiť ukryť nahrávaciu notifikáciu</string>
     <string name="save_recordings_in">Ukladať nahrávky do</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Viem nejakým spôsobom ukryť notifikačnú ikonku počas nahrávania?</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Kayıt bildirimini gizlemeyi dene</string>
     <string name="save_recordings_in">Kayıt klasörü:</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Kayıt sırasında bildirim simgesini gizleyebilir miyim?</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -18,6 +18,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Намагатися приховати сповіщення про запис</string>
     <string name="save_recordings_in">Місце зберігання записів</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Чи можна приховати значок сповіщення під час запису?</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">尝试隐藏录音通知提示</string>
     <string name="save_recordings_in">保存录音至</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">在录音过程中我可以隐藏通知提示图标么？</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <!-- Settings -->
     <string name="try_hiding_notification">Try hiding the recording notification</string>
     <string name="save_recordings_in">Save recordings in</string>
+    <string name="bitrate">Quality (bitrate)</string>
+    <string name="bitrate_value">%d kbps</string> <!-- Bitrate values like: 320 kbps, 128 kbps etc. -->
 
     <!-- FAQ -->
     <string name="faq_1_title">Can I hide the notification icon during recording?</string>


### PR DESCRIPTION
Hi,

I've added a bitrate setting to the app settings. It comes with some preconfigured values selectable for the user. Default is 128 kbps, the same as it was originally.
Despite the bitrate setting, Android itself can clip the bitrate value to the lower level in `prepare()` function. I haven't found a way to bypass it, so it may be possible, that despite setting 320 kbps it will record with bitrate 96 kbps (that was the case on my device).

https://user-images.githubusercontent.com/85929121/135751217-aaac4683-cec8-4000-bd8a-f66f5e4b0ae7.mp4