### PR TITLE
Added OPUS codec support (#38)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/activities/SettingsActivity.kt
@@ -10,8 +10,7 @@ import com.simplemobiletools.commons.helpers.isQPlus
 import com.simplemobiletools.commons.models.RadioItem
 import com.simplemobiletools.voicerecorder.R
 import com.simplemobiletools.voicerecorder.extensions.config
-import com.simplemobiletools.voicerecorder.helpers.EXTENSION_M4A
-import com.simplemobiletools.voicerecorder.helpers.EXTENSION_MP3
+import com.simplemobiletools.voicerecorder.helpers.*
 import kotlinx.android.synthetic.main.activity_settings.*
 import java.util.*
 
@@ -100,6 +99,10 @@ class SettingsActivity : SimpleActivity() {
             val items = arrayListOf(
                 RadioItem(EXTENSION_M4A, getString(R.string.m4a)),
                 RadioItem(EXTENSION_MP3, getString(R.string.mp3)))
+
+            if (isQPlus()) {
+                items.add(RadioItem(EXTENSION_OGG, getString(R.string.ogg)))
+            }
 
             RadioGroupDialog(this@SettingsActivity, items, config.extension) {
                 config.extension = it as Int

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Config.kt
@@ -1,6 +1,7 @@
 package com.simplemobiletools.voicerecorder.helpers
 
 import android.content.Context
+import android.media.MediaRecorder
 import com.simplemobiletools.commons.helpers.BaseConfig
 import com.simplemobiletools.voicerecorder.R
 
@@ -23,6 +24,17 @@ class Config(context: Context) : BaseConfig(context) {
 
     fun getExtensionText() = context.getString(when (extension) {
         EXTENSION_M4A -> R.string.m4a
+        EXTENSION_OGG -> R.string.ogg
         else -> R.string.mp3
     })
+
+    fun getOutputFormat() = when (extension) {
+        EXTENSION_OGG -> MediaRecorder.OutputFormat.OGG
+        else -> MediaRecorder.OutputFormat.MPEG_4
+    }
+
+    fun getAudioEncoder() = when (extension) {
+        EXTENSION_OGG -> MediaRecorder.AudioEncoder.OPUS
+        else -> MediaRecorder.AudioEncoder.AAC
+    }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Constants.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Constants.kt
@@ -16,6 +16,7 @@ const val TOGGLE_PAUSE = PATH + "TOGGLE_PAUSE"
 
 const val EXTENSION_M4A = 0
 const val EXTENSION_MP3 = 1
+const val EXTENSION_OGG = 2
 
 const val RECORDING_RUNNING = 0
 const val RECORDING_STOPPED = 1

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/services/RecorderService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/services/RecorderService.kt
@@ -74,8 +74,8 @@ class RecorderService : Service() {
         currFilePath = "$baseFolder/${getCurrentFormattedDateTime()}.${config.getExtensionText()}"
         recorder = MediaRecorder().apply {
             setAudioSource(MediaRecorder.AudioSource.CAMCORDER)
-            setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
-            setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+            setOutputFormat(config.getOutputFormat())
+            setAudioEncoder(config.getAudioEncoder())
             setAudioEncodingBitRate(128000)
             setAudioSamplingRate(44100)
 

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -3,5 +3,6 @@
     <string name="package_name">com.simplemobiletools.voicerecorder</string>
     <string name="m4a">m4a</string>
     <string name="mp3">mp3</string>
+    <string name="ogg">ogg</string>
 
 </resources>


### PR DESCRIPTION
Hi,

I've added support for OGG with OPUS codec as another option in Extensions setting. Support for OPUS was added in Android 10, so the option appears only on Q+ devices.

OGG is more known from Vorbis codec and I thought about adding it, but unfortunately Vorbis support in MediaRecorder is optional, so it's too risky to add it (it wasn't working for me on emulator and OnePlus devices). OPUS should be enough, since all new devices support it (and also nearly all new media players).

![image](https://user-images.githubusercontent.com/85929121/135766487-e06c530b-7d11-4692-825e-ae17dbfde76a.png)
