### PR TITLE
Fixed stopping playback after changing device orientation (#70)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,8 @@
 
         <activity
             android:name=".activities.MainActivity"
-            android:launchMode="singleTask" />
+            android:launchMode="singleTask"
+            android:configChanges="orientation|screenSize" />
 
         <activity
             android:name=".activities.SettingsActivity"


### PR DESCRIPTION
Hi,

I've fixed stopping the playback after changing device orientation by adding a property in Android Manifest. I've tested it on an emulator and a real device - it's working.