### PR TITLE
Prevented autoplay of the next recording on delete (#37)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/fragments/PlayerFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/fragments/PlayerFragment.kt
@@ -274,7 +274,7 @@ class PlayerFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
     override fun playRecording(recording: Recording, playOnPrepared: Boolean) {
         resetProgress(recording)
         (recordings_list.adapter as RecordingsAdapter).updateCurrentRecording(recording.id)
-        playOnPreparation = playOnPrepared || getIsPlaying()
+        playOnPreparation = playOnPrepared
 
         player!!.apply {
             reset()


### PR DESCRIPTION
Hi,

Despite the earlier fix, the next recording was still played after deleting the currently played one. As @mare5x found out, it was possible to fix it by changing one line. Now it works this way:
- After deleting the currently played recording, we are playing the next one.
- We set `playOnPreparation` to false, so we won't get an autoplay on view refresh. We ignore that something is currently playing, as contrary to the previous code.
- Player is set to the next recording, but since view has refreshed with `playOnPreparation = false`, it won't play.

Closes #37.

**Before:**

https://user-images.githubusercontent.com/85929121/151656395-56d517bb-1a43-46ad-95f6-973c6e4c3536.mp4

**After:**

https://user-images.githubusercontent.com/85929121/151656402-2631e06a-07a2-4dc5-816a-52b7feac772f.mp4
