### PR TITLE
allow users to customise recording folder

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.SimpleMobileTools:Simple-Commons:e3376e4f56'
+    implementation 'com.github.SimpleMobileTools:Simple-Commons:202656a071'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'com.github.Armen101:AudioRecordView:1.0.4'
     implementation 'androidx.documentfile:documentfile:1.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28" />
+        android:maxSdkVersion="29" />
 
     <uses-feature
         android:name="android.hardware.faketouch"

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/activities/MainActivity.kt
@@ -82,7 +82,7 @@ class MainActivity : SimpleActivity() {
     }
 
     private fun tryInitVoiceRecorder() {
-        if (isQPlus()) {
+        if (isRPlus()) {
             setupViewPager()
         } else {
             handlePermission(PERMISSION_WRITE_STORAGE) {

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/activities/SettingsActivity.kt
@@ -99,13 +99,20 @@ class SettingsActivity : SimpleActivity() {
     }
 
     private fun setupSaveRecordingsFolder() {
-        settings_save_recordings_holder.beGoneIf(isQPlus())
         settings_save_recordings.text = humanizePath(config.saveRecordingsFolder)
         settings_save_recordings_holder.setOnClickListener {
             FilePickerDialog(this, config.saveRecordingsFolder, false, showFAB = true) {
                 val path = it
-                handleSAFDialog(it) {
-                    if (it) {
+                handleSAFDialog(path) { grantedSAF ->
+                    if (!grantedSAF) {
+                        return@handleSAFDialog
+                    }
+
+                    handleSAFDialogSdk30(path) { grantedSAF30 ->
+                        if (!grantedSAF30) {
+                            return@handleSAFDialogSdk30
+                        }
+
                         config.saveRecordingsFolder = path
                         settings_save_recordings.text = humanizePath(config.saveRecordingsFolder)
                     }

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/adapters/RecordingsAdapter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/adapters/RecordingsAdapter.kt
@@ -116,10 +116,10 @@ class RecordingsAdapter(
 
     private fun shareRecordings() {
         val selectedItems = getSelectedItems()
-        val paths = if (isQPlus()) {
-            selectedItems.map { getAudioFileContentUri(it.id.toLong()).toString() }
-        } else {
-            selectedItems.map { it.path }
+        val paths = selectedItems.map {
+            it.path.ifEmpty {
+                getAudioFileContentUri(it.id.toLong()).toString()
+            }
         }
 
         activity.sharePathsIntent(paths, BuildConfig.APPLICATION_ID)

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/extensions/Context.kt
@@ -7,6 +7,10 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.Drawable
+import android.os.Environment
+import com.simplemobiletools.commons.extensions.internalStoragePath
+import com.simplemobiletools.commons.helpers.isQPlus
+import com.simplemobiletools.voicerecorder.R
 import com.simplemobiletools.voicerecorder.helpers.Config
 import com.simplemobiletools.voicerecorder.helpers.IS_RECORDING
 import com.simplemobiletools.voicerecorder.helpers.MyWidgetRecordDisplayProvider
@@ -32,5 +36,18 @@ fun Context.updateWidgets(isRecording: Boolean) {
             putExtra(IS_RECORDING, isRecording)
             sendBroadcast(this)
         }
+    }
+}
+
+fun Context.getDefaultRecordingsFolder(): String {
+    val defaultPath = getDefaultRecordingsRelativePath()
+    return "$internalStoragePath/$defaultPath"
+}
+
+fun Context.getDefaultRecordingsRelativePath(): String {
+    return if (isQPlus()) {
+        "${Environment.DIRECTORY_MUSIC}/Recordings"
+    } else {
+        getString(R.string.app_name)
     }
 }

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/fragments/PlayerFragment.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/fragments/PlayerFragment.kt
@@ -167,20 +167,24 @@ class PlayerFragment(context: Context, attributeSet: AttributeSet) : MyViewPager
     }
 
     private fun getRecordings(): ArrayList<Recording> {
+        val recordings = ArrayList<Recording>()
         return when {
             isRPlus() -> {
-                ArrayList(getMediaStoreRecordings() + getSAFRecordings()).apply {
-                    sortByDescending { it.timestamp }
-                }
+                recordings.addAll(getMediaStoreRecordings())
+                recordings.addAll(getSAFRecordings())
+                recordings
             }
             isQPlus() -> {
-                ArrayList(getMediaStoreRecordings() + getLegacyRecordings()).apply {
-                    sortByDescending { it.timestamp }
-                }
+                recordings.addAll(getMediaStoreRecordings())
+                recordings.addAll(getLegacyRecordings())
+                recordings
             }
             else -> {
-                getLegacyRecordings()
+                recordings.addAll(getLegacyRecordings())
+                recordings
             }
+        }.apply {
+            sortByDescending { it.timestamp }
         }
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/helpers/Config.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.media.MediaRecorder
 import com.simplemobiletools.commons.helpers.BaseConfig
 import com.simplemobiletools.voicerecorder.R
+import com.simplemobiletools.voicerecorder.extensions.getDefaultRecordingsFolder
 
 class Config(context: Context) : BaseConfig(context) {
     companion object {
@@ -15,7 +16,7 @@ class Config(context: Context) : BaseConfig(context) {
         set(hideNotification) = prefs.edit().putBoolean(HIDE_NOTIFICATION, hideNotification).apply()
 
     var saveRecordingsFolder: String
-        get() = prefs.getString(SAVE_RECORDINGS, "$internalStoragePath/${context.getString(R.string.app_name)}")!!
+        get() = prefs.getString(SAVE_RECORDINGS, context.getDefaultRecordingsFolder())!!
         set(saveRecordingsFolder) = prefs.edit().putString(SAVE_RECORDINGS, saveRecordingsFolder).apply()
 
     var extension: Int


### PR DESCRIPTION
## Notes
- use SAF on SDK 30+ to give users a chance to change the default location where recordings are stored

 ### AndroidManifest Changes
- since we have `requestLegacyExternalStorage="true"` in the `AndroidManifest`, we can enable `WRITE_EXTERNAL_STORAGE` up to SDK 29 (Android 10)

 ### Saving Recordings 
- modify methods to store recordings in `RecorderService` to use SAF for SDK 30+ and normal file paths for lower SDK versions.
- at first installation, the app would not have SAF permissions, so we use the old method, using `MediaStore` and the app's `cacheDir` until the users decide to change; then we can switch to using SAF

 ### Getting Recordings  
- modify methods to get all recordings in `PlayerFragment`
   - on SDK 30+, we need to combine recordings got from the `MediaStore` (`getMediaStoreRecordings`) and the ones from the recordings folder SAF (`getSAFRecordings`)
   - on SDK 29, we combine recordings got from the `MediaStore` (`getMediaStoreRecordings`) and the ones from direct file path (`getLegacyRecordings`)
   - on lower SDKs, we just use the file paths  (`getLegacyRecordings`)
   
 ### Playing Recordings  
- modify the method for playing recordings in `PlayerFragment`
   -  SDK 30+, when getting recordings with SAF, we store the string of the SAF URI of the file as the `Recording#path` field, we check if the path is a Document URI and pass that to the MediaPlayer#setDataSource method
   - if the `Recording#path` field is empty, we get the `MediaStore` URI using the ID and pass that to the `MediaPlayer#setDataSource` method
   - in other cases, the `Recording#path` field is a file path, so we use it.
   
 ### Sharing Recordings     
- in `RecordingsAdapter`, add support for changes to the paths used for sharing the recordings

 ### Commons module
- in `build.gradle`, update the `commons` module

https://user-images.githubusercontent.com/25648077/163721504-83b181a8-8c7f-48cc-8513-32994c790446.mp4


