### PR TITLE
Update targetSdkVersion to 34

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,12 +9,12 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "com.simplemobiletools.voicerecorder"
         minSdkVersion 23
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 37
         versionName "5.11.4"
         setProperty("archivesBaseName", "voice-recorder")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
@@ -106,6 +107,7 @@
 
         <service
             android:name=".services.RecorderService"
+            android:foregroundServiceType="microphone"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.simplemobiletools.voicerecorder.action.GET_RECORDER_INFO" />

--- a/app/src/main/kotlin/com/simplemobiletools/voicerecorder/services/RecorderService.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/voicerecorder/services/RecorderService.kt
@@ -273,7 +273,7 @@ class RecorderService : Service() {
             visibility = NotificationCompat.VISIBILITY_SECRET
         }
 
-        val builder = NotificationCompat.Builder(this)
+        val builder = NotificationCompat.Builder(this, channelId)
             .setContentTitle(title)
             .setContentText(text)
             .setSmallIcon(icon)
@@ -283,7 +283,6 @@ class RecorderService : Service() {
             .setSound(null)
             .setOngoing(true)
             .setAutoCancel(true)
-            .setChannelId(channelId)
 
         return builder.build()
     }


### PR DESCRIPTION
Regardless of updating targetSdkVersion, the foreground service notification will now be dismissable by the user. Ongoing flag will only affect dismissing with *Clear all* or when phone is locked.

Updating targetSdkVersion required updating the RecorderService type, since these are now mandatory. Setting `microphone` type also required additional permission, `FOREGROUND_SERVICE_MICROPHONE`.

No other changes from these lists affects this app:
- https://developer.android.com/about/versions/14/behavior-changes-all
- https://developer.android.com/about/versions/14/behavior-changes-14