### PR TITLE
Keep androidx compose runtime classes to prevent crash on about button

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -4,3 +4,5 @@
     @org.greenrobot.eventbus.Subscribe <methods>;
 }
 -keep enum org.greenrobot.eventbus.ThreadMode { *; }
+
+-keep class androidx.compose.runtime.** { *; }


### PR DESCRIPTION
This closes #221